### PR TITLE
Fix #3

### DIFF
--- a/CriminalDance/CriminalDanceBot/CriminalDance.cs
+++ b/CriminalDance/CriminalDanceBot/CriminalDance.cs
@@ -871,6 +871,7 @@ namespace CriminalDanceBot
                     {
                         UseCard(p2, cardChosen, true);
                         p2.Cards.Add(p.TempCard); //get the dog as compensation
+                        p2.UsedUp = false; //make sure that after getting a card as compensation UsedUp will not be true
                         Send(GetTranslation("DogTransferCard", GetName(p), GetName(p2), GetName(cardChosen)));
                         p.CardChanged = true;
                         p2.CardChanged = true;


### PR DESCRIPTION
If Dog card is used against a player with only a card the count of that player will be 0 and the UsedUp will be true, but Dog has the peculiarity to give a card in return so the count will be 1 again but UsedUp is still true so players are able to skip Information Exchange.